### PR TITLE
Update set_printoptions(threshold=np.inf)

### DIFF
--- a/scope/tfutils.py
+++ b/scope/tfutils.py
@@ -44,7 +44,7 @@ class NumpyPrintEverything:
 
   def __enter__(self):
     self.saved_threshold = np.get_printoptions()['threshold']
-    np.set_printoptions(threshold=np.nan)
+    np.set_printoptions(threshold=np.inf)
 
   def __exit__(self, type, value, traceback):
     np.set_printoptions(threshold=self.saved_threshold)


### PR DESCRIPTION
Change set_printoptions(threshold=np.nan) to np.inf

These lines throw an error in Numpy 1.16
"ValueError: threshold must be numeric and non-NAN, try sys.maxsize for untruncated representation"

See https://github.com/numpy/numpy/pull/12353